### PR TITLE
Fix manifest include

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-global-include *.html
+recursive-include pbshm *.html
 exclude pbshm/__init__.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-channel-toolbox"
-version = "0.1"
+version = "0.1.1"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]


### PR DESCRIPTION
The manifest was inadvertently including HTML files from installed packages, instead of just the PBSHM namespace.