### PR TITLE
Fix site package select

### DIFF
--- a/pbshm/__init__.py
+++ b/pbshm/__init__.py
@@ -32,9 +32,23 @@ def create_app(test_config=None):
     except OSError:
         pass
 
+    #Calculate site packages folder
+    pbshm_directory, package_paths = None, site.getsitepackages()
+    selected_package_path = os.path.join(package_paths[1 if len(package_paths) > 1 and sys.platform == "win32" else 0], "pbshm")
+    if os.path.isdir(selected_package_path): pbshm_directory = selected_package_path
+    else:
+        for path in package_paths:
+            potential_path = os.path.join(path, "pbshm")
+            if potential_path == selected_package_path:
+                continue
+            elif os.path.isdir(potential_path):
+                pbshm_directory = potential_path
+                break
+    if pbshm_directory is None:
+        raise Exception(f"Unable to find site packages with the PBSHM namespace, paths searched: {package_paths}")
+    
     #Include PBSHM Core Packages
     importlib.invalidate_caches()
-    pbshm_directory = os.path.join(site.getsitepackages()[0], "pbshm")
     pbshm_modules = {
         "pbshm.db": {
             "path": ["db.py"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pbshm-channel-toolbox"
-version = "0.1.2"
+version = "0.1.3"
 authors = [
     { name = "Dan Brennan", email = "d.s.brennan@sheffield.ac.uk" }
 ]


### PR DESCRIPTION
The system previously selected the first site package as the location for the pbshm namespace; however, this may not be correct in every circumstance. As such, the system will now scan all of the returned locations to search for the pbshm namespace.