### PR TITLE
Increment artifact actions to v4

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -14,7 +14,7 @@ jobs:
                 python-version: "3.x"
             - run: python3 -m pip install build --user
             - run: python3 -m build
-            - uses: actions/upload-artifact@v3
+            - uses: actions/upload-artifact@v4
               with:
                 name: pypi-package
                 path: dist/
@@ -29,7 +29,7 @@ jobs:
         permissions:
             id-token: write
         steps:
-            - uses: actions/download-artifact@v3
+            - uses: actions/download-artifact@v4
               with:
                 name: pypi-package
                 path: dist/


### PR DESCRIPTION
The github action artifact v3 has been depreciated; therefore bump the version to v4. 